### PR TITLE
Add log_date_format option to pm2-env.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ $ pm2-meteor init
   },
   // optional - set this one if you want to undeploy your app
   // "allowUndeploy": true
+
+  // optional - set this if you want to specify timestamps to the pm2 log-files
+  // "log_date_format": "YYYY-MM-DD HH:mm Z"
 }
 ```
 

--- a/src/localTasks.coffee
+++ b/src/localTasks.coffee
@@ -52,6 +52,8 @@ module.exports =
     appJson.script = path.join(pm2mConf.server.deploymentDir, pm2mConf.appName, "bundle/main.js")
     appJson.exec_mode = pm2mConf.server.exec_mode
     appJson.instances = pm2mConf.server.instances
+    if pm2mConf.server.log_date_format and pm2mConf.server.log_date_format isnt ""
+      appJson.log_date_format = pm2mConf.server.log_date_format
     # get Meteor settings
     meteorSettingsObj = {}
     if pm2mConf.meteorSettingsLocation and !pm2mConf.meteorSettingsInRepo


### PR DESCRIPTION
Added an optional **log_date_format** argument to pm2-meteor.json.
This way, you can have pm2 automatically add timestamps to it's logs

I had to update pm2-env.json by hand after each deploy to get timestamps in my logs.  This should fix it.
`"log_date_format": "YYYY-MM-DD HH:mm Z"`

( I'm not a CF expert, and it's my first PR ever, so comments welcome )
