### PR TITLE
after the patch, we can specify node version by passing argument to PM2

### DIFF
--- a/src/localTasks.coffee
+++ b/src/localTasks.coffee
@@ -63,6 +63,7 @@ module.exports =
     appJson.script = path.join(pm2mConf.server.deploymentDir, pm2mConf.appName, "bundle/main.js")
     appJson.exec_mode = pm2mConf.server.exec_mode
     appJson.instances = pm2mConf.server.instances
+    appJson.exec_interpreter = pm2mConf.server.exec_interpreter
     if pm2mConf.server.log_date_format and pm2mConf.server.log_date_format isnt ""
       appJson.log_date_format = pm2mConf.server.log_date_format
     # get Meteor settings

--- a/src/remoteTasks.coffee
+++ b/src/remoteTasks.coffee
@@ -30,8 +30,8 @@ class BashCmd
     if nvm
       if nvm.bin
         result = appendCmd result, "[[ -r #{nvm.bin} ]] && . #{nvm.bin}"
-        # if nvm.use
-        #   result = appendCmd result, "nvm use #{nvm.use}"
+        if nvm.use
+        result = appendCmd result, "nvm use #{nvm.use}"
     result = appendCmd result, @rawCmd
     return result
 


### PR DESCRIPTION
but the cluster mode failed to work, i don't know why.

i know this solution is not good,

because it might still using the node version that nvm alias defaultly

the "nvm.use" tricks server to check node, npm and pm2 available with specify version

but at least we have idea how to make it work.

@andruschka pls help and add nvm support

love love from harbin