### PR TITLE
Add ssh-agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ $ pm2-meteor init
     // "pem":"~/.ssh/id_rsa",
     // optional - set port
     // "port": "22",
+    // or with ssh-agent
+    // unix socket for ssh-agent will be read from $SSH_AUTH_SOCK environment variable
+    // "useAgent": true
 
     // this dir will contain your apps
     // (app will be deployed to /opt/pm2-meteor/ninjaApp)

--- a/lib/remoteTasks.js
+++ b/lib/remoteTasks.js
@@ -78,9 +78,10 @@
         password: pm2mConf.server.password ? pm2mConf.server.password : void 0,
         pem: pm2mConf.server.pem ? fs.readFileSync(abs(pm2mConf.server.pem)) : void 0
       }, {
-        ssh: pm2mConf.server.port ? {
-          port: pm2mConf.server.port
-        } : void 0
+        ssh: {
+          agent: (pm2mConf.server.useAgent ? process.env.SSH_AUTH_SOCK : void 0),
+          port: (pm2mConf.server.port ? pm2mConf.server.port : void 0)
+        }
       });
       return session;
     },

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -27,6 +27,7 @@
         host: "",
         username: "",
         password: "",
+        useAgent: false,
         deploymentDir: "/opt/meteor-apps",
         loadProfile: "",
         nvm: {

--- a/src/remoteTasks.coffee
+++ b/src/remoteTasks.coffee
@@ -47,7 +47,8 @@ module.exports =
       pem: fs.readFileSync(abs(pm2mConf.server.pem)) if pm2mConf.server.pem
     ,
       ssh:
-        port: pm2mConf.server.port if pm2mConf.server.port
+        agent: (process.env.SSH_AUTH_SOCK if pm2mConf.server.useAgent)
+        port: (pm2mConf.server.port if pm2mConf.server.port)
     return session
   checkDeps: (session, pm2mConf, done)->
     cmd = cmdString pm2mConf, "(command -v node || echo 'missing node' 1>&2) && (command -v npm || echo 'missing npm' 1>&2) && (command -v pm2 || echo 'missing pm2' 1>&2)"

--- a/src/settings.coffee
+++ b/src/settings.coffee
@@ -21,6 +21,7 @@ module.exports =
       host: ""
       username: ""
       password: ""
+      useAgent: false
       deploymentDir: "/opt/meteor-apps"
       loadProfile: ""
       nvm:


### PR DESCRIPTION
This change makes possible to use [ssh-agent](https://linux.die.net/man/1/ssh-agent) with a simple server option.

Instead of providing a password or pem file, one can simply pass `"useAgent": true` in `pm2-meteor.json`. By setting this value to true, `SSH_AUTH_SOCK` environment variable (which holds the unix-domain socket created by ssh-agent) will be passed to `nodemiral`.

This change will make possible to use encrypted private keys with `pm2-meteor`.

Fixes #36, #10 